### PR TITLE
Fix  typesense url address in search modal footer logo

### DIFF
--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -405,7 +405,7 @@ function SearchPage() {
             <a
               target="_blank"
               rel="noopener noreferrer"
-              href="https://www.algolia.com/"
+              href="https://typesense.org/"
               aria-label={translate({
                 id: 'theme.SearchPage.algoliaLabel',
                 message: 'Search by Typesense',


### PR DESCRIPTION
## Change Summary
Fix  typesense url address in search modal footer logo
