### PR TITLE
Fix TypeScript type definitions for Algolia search helper parameters

### DIFF
--- a/src/theme/SearchPage/index.tsx
+++ b/src/theme/SearchPage/index.tsx
@@ -11,6 +11,7 @@ import React, {useEffect, useState, useReducer, useRef} from 'react';
 import clsx from 'clsx';
 
 import algoliaSearchHelper from 'algoliasearch-helper';
+import type {SearchParameters} from 'algoliasearch-helper';
 
 import Head from '@docusaurus/Head';
 import Link from '@docusaurus/Link';
@@ -233,14 +234,18 @@ function SearchPageContent(): JSX.Element {
       ...typesenseSearchParameters,
     },
   });
+
+  // Needed this to avoid a typescript error in algoliaSearchHelper
+  const searchParams: Partial<SearchParameters> = {
+    hitsPerPage: 15,
+    advancedSyntax: true,
+    disjunctiveFacets: ['language', 'docusaurus_tag'],
+  };
+
   const algoliaHelper = algoliaSearchHelper(
     typesenseInstantSearchAdapter.searchClient,
     typesenseCollectionName,
-    {
-      hitsPerPage: 15,
-      advancedSyntax: true,
-      disjunctiveFacets: ['language', 'docusaurus_tag'],
-    },
+    searchParams,
   );
 
   algoliaHelper.on(


### PR DESCRIPTION
## Change Summary
# What is this?
This PR addresses a TypeScript compilation error in the search functionality of our Docusaurus theme. The error occurs because the type definitions for the Algolia search helper parameters were not properly defined, causing TypeScript to reject valid search configuration options like `hitsPerPage`. This fix ensures proper type safety while maintaining the existing search functionality.

The issue was causing TypeScript to throw errors when valid search parameters were being passed to the Algolia search helper, making it difficult to maintain type safety in our codebase. By explicitly defining the search parameters using the correct type from `algoliasearch-helper`, we ensure both type safety and correct runtime behavior.

# Changes

## Code Changes:
1. **In `src/theme/SearchPage/index.tsx`**:
    - Added import for `SearchParameters` type from `algoliasearch-helper`
    - Introduced a properly typed search parameters object using `Partial<SearchParameters>`
    - Refactored the `algoliaHelper` initialization to use the typed parameters
    - Parameters remain unchanged functionally:
      - `hitsPerPage`: 15 results per page
      - `advancedSyntax`: enabled for better search capabilities
      - `disjunctiveFacets`: configured for 'language' and 'docusaurus_tag'

# Context
The issue stemmed from a type definition mismatch where `PlainSearchParameters` didn't properly expose all valid search options. Rather than using type assertions or ignoring TypeScript errors, we opted for a proper type-safe solution using the `SearchParameters` type directly from the Algolia helper library.

This change:
- Maintains runtime behavior exactly as before
- Adds proper type safety
- Makes the code more maintainable
- Follows TypeScript best practices by using proper type definitions

The solution is minimal and focused, touching only the specific file where the type error occurred while providing a proper fix that aligns with the TypeScript type system.


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
