### PR TITLE
fix(deps): peer dependencies for docusaurus 3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "typescript": "~5.6.2"
   },
   "peerDependencies": {
-    "@docusaurus/core": "~3.8.0",
-    "@docusaurus/theme-common": "~3.8.0",
+    "@docusaurus/core": "~3.9.0",
+    "@docusaurus/theme-common": "~3.9.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },


### PR DESCRIPTION
## Change Summary

With https://github.com/typesense/docusaurus-theme-search-typesense/pull/69, Docusaurus 3.9.x is supported but it still display a warning in yarn output:

```bash
➤ YN0060: │ @docusaurus/core is listed by your project with version 3.9.2 (p3e5822), which doesn't satisfy what docusaurus-theme-search-typesense and other dependencies request (~3.8.0).
➤ YN0060: │ @docusaurus/theme-common is listed by your project with version 3.9.2 (p4af2a3), which doesn't satisfy what docusaurus-theme-search-typesense requests (~3.8.0).
```

This warning seems to be caused by the `peerDependencies` section that is still pointing to `3.8.x`. This PR aims to fix that.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
