### PR TITLE
fix(search): preserve query params in result urls

### DIFF
--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -191,7 +191,7 @@ function DocSearch({
         const url = new URL(item.url);
         return {
           ...item,
-          url: withBaseUrl(`${url.pathname}${url.hash}`),
+          url: withBaseUrl(`${url.pathname}${url.search}${url.hash}`),
         };
       }),
   ).current;

--- a/src/theme/SearchPage/index.tsx
+++ b/src/theme/SearchPage/index.tsx
@@ -286,7 +286,7 @@ function SearchPageContent(): JSX.Element {
             title: titles.pop()!,
             url: isRegexpStringMatch(externalUrlRegex, parsedURL.href)
               ? parsedURL.href
-              : parsedURL.pathname + parsedURL.hash,
+              : parsedURL.pathname + parsedURL.search + parsedURL.hash,
             summary: snippet.content
               ? `${sanitizeValue(snippet.content.value)}...`
               : '',


### PR DESCRIPTION
## Change Summary
- include `url.search` when normalizing internal links in `SearchBar`
- include `parsedURL.search` when building non-external links in `SearchPage`
- fix #48 


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
