### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "access": "public"
   },
   "repository": "typesense/docusaurus-theme-search-typesense",
+  "homepage": "https://github.com/typesense/docusaurus-theme-search-typesense#readme",
+  "bugs": {
+    "url": "https://github.com/typesense/docusaurus-theme-search-typesense/issues"
+  },
   "license": "MIT",
   "scripts": {
     "build": "tsc --build && node copyUntypedFiles.mjs && prettier --config .prettierrc --write \"src/**/*.{js,ts,tsx,css}\"",


### PR DESCRIPTION
## Summary
- add npm homepage metadata for docusaurus-theme-search-typesense
- add npm bugs.url metadata pointing to the GitHub issue tracker

## Verification
- node -e "const p=require('./package.json'); if(p.name!=='docusaurus-theme-search-typesense'||p.homepage!=='https://github.com/typesense/docusaurus-theme-search-typesense#readme'||p.bugs?.url!=='https://github.com/typesense/docusaurus-theme-search-typesense/issues') process.exit(1); console.log('package metadata OK')"
- npm pack --dry-run --ignore-scripts --json
- git diff --check