### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "docusaurus-theme-search-typesense",
   "version": "0.26.0",
+  "bugs": {
+    "url": "https://github.com/typesense/docusaurus-theme-search-typesense/issues"
+  },
   "description": "Typesense search component for Docusaurus.",
   "main": "lib/index.js",
   "sideEffects": [


### PR DESCRIPTION
Adds missing `bugs` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.